### PR TITLE
Update for node 12

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@
       return false;
     }
 
-    outputBuffer = new Buffer(inputBuffer.readUInt32LE(8));
+    outputBuffer = Buffer.alloc(inputBuffer.readUInt32LE(8));
 
     lz4.decodeBlock(inputBuffer, outputBuffer, 12);
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^2.9.0",
-    "lz4": "^0.5.3"
+    "lz4": "^0.6.3"
   },
   "repository": "thrilleratplay/node-jsonlz4-decompress"
 }


### PR DESCRIPTION
The latest version of `jsonlz4-decompress` (0.0.2) depends on the `0.5.X` branch of `lz4` which does not build under Node.js v12. So it is currently not possible to install `jsonlz4-decompress` from npm under Node.js v12. I updated the dependency to `"^0.6.3"` and everything seems to work just fine.

In addition to above issue, running `jsonlz4-decompress` under Node.js v12 gives following warning:

    (node:43724) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
